### PR TITLE
add flag for allowing case insensitive replacements

### DIFF
--- a/rotate-text.el
+++ b/rotate-text.el
@@ -36,10 +36,10 @@
 ;; (autoload 'rotate-text "rotate-text" nil t)
 ;; (autoload 'rotate-text-backward "rotate-text" nil t)
 ;;
-;; Customize the variables `rotate-text-patterns', `rotate-text-symbols' and
-;; `rotate-text-words'.  You can make buffer-local additions in
-;; `rotate-text-local-patterns', `rotate-text-local-symbols' and
-;; `rotate-text-local-words'.
+;; Customize the variables `rotate-text-patterns', `rotate-text-symbols',
+;; `rotate-text-words' and `rotate-text-use-defined-casing'.  You can make
+;; buffer-local additions in `rotate-text-local-patterns',
+;; `rotate-text-local-symbols' and `rotate-text-local-words'.
 ;;
 ;; Use the commands `rotate-text' and `rotate-text-backward' to rotate the
 ;; text.

--- a/rotate-text.el
+++ b/rotate-text.el
@@ -90,6 +90,14 @@ text."
   :group 'rotate-text
   :type '(repeat (repeat :tag "Rotation group" (string :tag "Word"))))
 
+
+(defcustom rotate-text-use-defined-casing nil
+  "* Flag that determines whether `rotate-text' keeps casing of matched symbol.
+If set to true, the casing of word defined in `rotate-text-symbols' and
+`rotate-text-local-symbols' is used."
+  :group 'rotate-text
+  :type 'boolean)
+
 (defvar rotate-text-local-patterns nil
   "*Buffer local additions to `rotate-text-patterns'.")
 (make-variable-buffer-local 'rotate-text-local-patterns)
@@ -216,7 +224,7 @@ COM-SYMBOLS, COM-WORDS and COM-PATTERNS are per-command addition to `rotate-text
                     'end
                   (- pos (match-beginning 0)))))
 
-        (replace-match replacement nil t)
+        (replace-match replacement rotate-text-use-defined-casing t)
 
         (goto-char (if (eq rotate-text-last-offset 'end)
                        (match-end 0)


### PR DESCRIPTION
I know it's been a while since you updated the code. Hope I can help improve it a little though ;) 
I have added a flag for case insensitive replacement in order to make rotating symbols like `'("Titlecase" "UPPERCASE")` work.
Until now there was no way to rotate between those symbols:  `UPPERCASE` will be rotated into `TITLECASE`.
Now you can `(setq rotate-text-use-defined-casing t)` and it will work.